### PR TITLE
Fix data logging and pump log persistence

### DIFF
--- a/public/get_hourly.php
+++ b/public/get_hourly.php
@@ -3,22 +3,21 @@ $DB_HOST="vps2.haris-iot.my.id"; $DB_USER="manunggal"; $DB_PASS="jaya333"; $DB_N
 header("Content-Type: application/json");
 
 $days = isset($_GET['days']) ? max(1, min(365, (int)$_GET['days'])) : 30;
-$device_id = isset($_GET['device_id']) ? substr(trim($_GET['device_id']),0,64) : 'esp32-1';
 
 $mysqli = @new mysqli($DB_HOST,$DB_USER,$DB_PASS,$DB_NAME);
 if ($mysqli->connect_errno) { http_response_code(500); echo json_encode(["ok"=>false,"error"=>"DB connect: ".$mysqli->connect_error]); exit; }
 
 $stmt = $mysqli->prepare("
   SELECT UNIX_TIMESTAMP(hour_start) AS hour_start,
-         ph_avg, soil_avg, temp_avg
+         ph_avg, kelembapan_avg, suhu_avg
   FROM sensor_hourly
-  WHERE device_id=? AND hour_start >= (UTC_TIMESTAMP() - INTERVAL ? DAY)
+  WHERE hour_start >= (UTC_TIMESTAMP() - INTERVAL ? DAY)
   ORDER BY hour_start ASC
 ");
-$stmt->bind_param("si", $device_id, $days);
+$stmt->bind_param("i", $days);
 $stmt->execute();
 $res = $stmt->get_result();
 $rows = [];
 while ($r = $res->fetch_assoc()) { $rows[] = $r; }
 
-echo json_encode(["ok"=>true, "device_id"=>$device_id, "days"=>$days, "data"=>$rows]);
+echo json_encode(["ok"=>true, "days"=>$days, "data"=>$rows]);

--- a/public/get_pump_logs.php
+++ b/public/get_pump_logs.php
@@ -1,0 +1,26 @@
+<?php
+$DB_HOST="vps2.haris-iot.my.id"; $DB_USER="manunggal"; $DB_PASS="jaya333"; $DB_NAME="manunggaljaya";
+header("Content-Type: application/json");
+
+$limit = isset($_GET['limit']) ? max(1, min(100, (int)$_GET['limit'])) : 20;
+
+$mysqli = @new mysqli($DB_HOST,$DB_USER,$DB_PASS,$DB_NAME);
+if($mysqli->connect_errno){
+  http_response_code(500);
+  echo json_encode(["ok"=>false,"error"=>"DB connect: ".$mysqli->connect_error]);
+  exit;
+}
+
+$stmt = $mysqli->prepare("SELECT started_at, duration_sec, reason, action, note FROM pump_logs ORDER BY started_at DESC LIMIT ?");
+if(!$stmt){
+  http_response_code(500);
+  echo json_encode(["ok"=>false,"error"=>"Prepare failed"]);
+  exit;
+}
+$stmt->bind_param("i", $limit);
+$stmt->execute();
+$res = $stmt->get_result();
+$rows = [];
+while($r = $res->fetch_assoc()) { $rows[] = $r; }
+
+echo json_encode(["ok"=>true, "limit"=>$limit, "data"=>$rows]);

--- a/public/get_realtime.php
+++ b/public/get_realtime.php
@@ -3,21 +3,20 @@ $DB_HOST="vps2.haris-iot.my.id"; $DB_USER="manunggal"; $DB_PASS="jaya333"; $DB_N
 header("Content-Type: application/json");
 
 $hours = isset($_GET['hours']) ? max(1, min(48, (int)$_GET['hours'])) : 6;
-$device_id = isset($_GET['device_id']) ? substr(trim($_GET['device_id']),0,64) : 'esp32-1';
 
 $mysqli = @new mysqli($DB_HOST,$DB_USER,$DB_PASS,$DB_NAME);
 if ($mysqli->connect_errno) { http_response_code(500); echo json_encode(["ok"=>false,"error"=>"DB connect: ".$mysqli->connect_error]); exit; }
 
 $stmt = $mysqli->prepare("
-  SELECT UNIX_TIMESTAMP(ts) AS t, suhu, kelembapan_tanah, pH
+  SELECT UNIX_TIMESTAMP(ts) AS t, suhu, kelembapan_tanah, ph, relay
   FROM sensor_realtime
-  WHERE device_id=? AND ts >= (NOW() - INTERVAL ? HOUR)
+  WHERE ts >= (NOW() - INTERVAL ? HOUR)
   ORDER BY ts ASC
 ");
-$stmt->bind_param("si", $device_id, $hours);
+$stmt->bind_param("i", $hours);
 $stmt->execute();
 $res = $stmt->get_result();
 $rows = [];
 while ($r = $res->fetch_assoc()) { $rows[] = $r; }
 
-echo json_encode(["ok"=>true, "device_id"=>$device_id, "hours"=>$hours, "data"=>$rows]);
+echo json_encode(["ok"=>true, "hours"=>$hours, "data"=>$rows]);

--- a/public/index.html
+++ b/public/index.html
@@ -590,6 +590,7 @@
       togglePump(sensorData.pumpStatus, false);
       updateLastUpdateTime();
       updateScheduleStatuses();
+      loadPumpLogs();
     }
 
     function switchTab(tabName) {
@@ -718,15 +719,36 @@
     }
 
     // ================== LOGS ==================
-    function addLog(message){
+    function addLog(message, time=null){
       const list = document.getElementById('logList');
       if(!list) return;
-      const time = new Date().toLocaleString();
+      const ts = time || new Date().toLocaleString();
       const item = document.createElement('li');
-      item.textContent = `[${time}] ${message}`;
+      item.textContent = `[${ts}] ${message}`;
       list.prepend(item);
       const max = 100;
       while(list.children.length > max){ list.removeChild(list.lastChild); }
+    }
+
+    function loadPumpLogs(){
+      fetch('get_pump_logs.php?limit=20')
+        .then(r=>r.json())
+        .then(res=>{
+          if(res.ok){
+            res.data.reverse().forEach(log=>{
+              const time = new Date(log.started_at.replace(' ','T')).toLocaleString();
+              addLog(`Pump ${log.action}`, time);
+            });
+          }
+        }).catch(()=>{});
+    }
+
+    function sendPumpLog(action, reason){
+      fetch('log_pump.php', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({action, reason})
+      }).catch(()=>{});
     }
 
     // ================== RELAY ==================
@@ -740,7 +762,10 @@
         status.className = isOn ? 'pump-status on' : 'pump-status off';
         status.innerHTML = `<i class="fas fa-power-off"></i> PUMP ${isOn?'ON':'OFF'}`;
       }
-      if(prev !== sensorData.pumpStatus){ addLog(`Pump ${sensorData.pumpStatus?'ON':'OFF'}`); }
+      if(prev !== sensorData.pumpStatus){
+        addLog(`Pump ${sensorData.pumpStatus?'ON':'OFF'}`);
+        sendPumpLog(sensorData.pumpStatus?'ON':'OFF', shouldPublish ? 'manual' : 'other');
+      }
       if (shouldPublish) safePublishRelay(!!isOn);
       updateLastUpdateTime();
     }

--- a/public/log_pump.php
+++ b/public/log_pump.php
@@ -1,0 +1,46 @@
+<?php
+$DB_HOST="vps2.haris-iot.my.id"; $DB_USER="manunggal"; $DB_PASS="jaya333"; $DB_NAME="manunggaljaya";
+header("Content-Type: application/json");
+
+if($_SERVER['REQUEST_METHOD'] !== 'POST'){
+  http_response_code(405);
+  echo json_encode(["ok"=>false, "error"=>"Method not allowed, use POST"]);
+  exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+if(!is_array($data)){
+  http_response_code(400);
+  echo json_encode(["ok"=>false, "error"=>"Invalid JSON"]);
+  exit;
+}
+
+$action = strtoupper($data['action'] ?? 'ON');
+if(!in_array($action, ['ON','OFF'])) $action = 'ON';
+$reason = strtolower($data['reason'] ?? 'manual');
+if(!in_array($reason, ['manual','schedule','moisture','other'])) $reason = 'other';
+$duration = isset($data['duration_sec']) ? (int)$data['duration_sec'] : null;
+$note = isset($data['note']) ? substr($data['note'],0,255) : null;
+
+$mysqli = @new mysqli($DB_HOST,$DB_USER,$DB_PASS,$DB_NAME);
+if($mysqli->connect_errno){
+  http_response_code(500);
+  echo json_encode(["ok"=>false,"error"=>"DB connect: ".$mysqli->connect_error]);
+  exit;
+}
+
+$stmt = $mysqli->prepare("INSERT INTO pump_logs (duration_sec, reason, action, note) VALUES (?,?,?,?)");
+if(!$stmt){
+  http_response_code(500);
+  echo json_encode(["ok"=>false,"error"=>"Prepare failed"]);
+  exit;
+}
+$stmt->bind_param("isss", $duration, $reason, $action, $note);
+$ok = $stmt->execute();
+if(!$ok){
+  http_response_code(500);
+  echo json_encode(["ok"=>false,"error"=>"Execute failed: ".$stmt->error]);
+  exit;
+}
+
+echo json_encode(["ok"=>true, "id"=>$stmt->insert_id]);

--- a/public/senddata.php
+++ b/public/senddata.php
@@ -12,17 +12,17 @@ if (($_SERVER['HTTP_X_API_KEY'] ?? '') !== $API_KEY) { http_response_code(401); 
 $data = json_decode(file_get_contents("php://input"), true);
 if (!is_array($data)) { http_response_code(400); echo json_encode(["ok"=>false,"error"=>"Invalid JSON"]); exit; }
 
-$device_id = isset($data['device_id']) ? substr(trim($data['device_id']), 0, 64) : 'esp32-1';
-$suhu = array_key_exists('suhu',$data) ? (is_null($data['suhu'])?null:(float)$data['suhu']) : null;
-$soil = array_key_exists('kelembapan_tanah',$data) ? (is_null($data['kelembapan_tanah'])?null:(int)$data['kelembapan_tanah']) : null;
-$ph   = array_key_exists('ph',$data) ? (is_null($data['ph'])?null:(float)$data['ph']) : null;
+$suhu  = array_key_exists('suhu',$data) ? (is_null($data['suhu'])?null:(float)$data['suhu']) : null;
+$soil  = array_key_exists('kelembapan_tanah',$data) ? (is_null($data['kelembapan_tanah'])?null:(int)$data['kelembapan_tanah']) : null;
+$ph    = array_key_exists('ph',$data) ? (is_null($data['ph'])?null:(float)$data['ph']) : null;
+$relay = array_key_exists('relay',$data) ? (int)$data['relay'] : 0;
 
 $mysqli = @new mysqli($DB_HOST,$DB_USER,$DB_PASS,$DB_NAME);
 if ($mysqli->connect_errno) { http_response_code(500); echo json_encode(["ok"=>false,"error"=>"DB connect: ".$mysqli->connect_error]); exit; }
 
-$stmt = $mysqli->prepare("INSERT INTO sensor_realtime (device_id, suhu, kelembapan_tanah, pH) VALUES (?,?,?,?)");
+$stmt = $mysqli->prepare("INSERT INTO sensor_realtime (suhu, kelembapan_tanah, ph, relay) VALUES (?,?,?,?)");
 if (!$stmt) { http_response_code(500); echo json_encode(["ok"=>false,"error"=>"Prepare failed"]); exit; }
-$stmt->bind_param("sdid", $device_id, $suhu, $soil, $ph);
+$stmt->bind_param("didi", $suhu, $soil, $ph, $relay);
 $ok = $stmt->execute();
 if (!$ok) { http_response_code(500); echo json_encode(["ok"=>false,"error"=>"Execute failed: ".$stmt->error]); exit; }
 


### PR DESCRIPTION
## Summary
- Align sensor endpoints with actual DB column names and add relay support
- Provide APIs to store and fetch pump logs
- Persist pump events from dashboard and render saved logs

## Testing
- `php -l public/senddata.php`
- `php -l public/get_realtime.php`
- `php -l public/get_hourly.php`
- `php -l public/log_pump.php`
- `php -l public/get_pump_logs.php`


------
https://chatgpt.com/codex/tasks/task_e_689df353db208325af71ba6bba169102