### PR TITLE
Add database setup guide and load chart data from DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Dashboard IoT Manunggal
+
+Proyek ini menampilkan data sensor dan kontrol pompa melalui web. Aplikasi berjalan di atas PHP sederhana dengan Chart.js untuk menampilkan grafik.
+
+## Menjalankan Aplikasi
+
+1. Pastikan **Docker** dan **Docker Compose** terpasang.
+2. Jalankan layanan web:
+   ```bash
+   docker-compose up -d
+   ```
+3. Buka `http://localhost:5500` di peramban.
+
+## Konfigurasi Basis Data
+
+Aplikasi memerlukan basis data MySQL/MariaDB. Atur kredensial di setiap berkas PHP (`get_realtime.php`, `get_hourly.php`, `senddata.php`, dll.) pada variabel `$DB_HOST`, `$DB_USER`, `$DB_PASS`, dan `$DB_NAME`.
+
+### Struktur Tabel
+Jalankan perintah berikut di basis data yang digunakan:
+
+```sql
+CREATE TABLE sensor_realtime (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  suhu DOUBLE,
+  kelembapan_tanah INT,
+  ph DOUBLE,
+  relay TINYINT
+);
+
+CREATE TABLE sensor_hourly (
+  hour_start DATETIME NOT NULL,
+  suhu_avg DOUBLE,
+  kelembapan_avg DOUBLE,
+  ph_avg DOUBLE,
+  PRIMARY KEY (hour_start)
+);
+
+CREATE TABLE pump_logs (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  started_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  duration_sec INT,
+  reason VARCHAR(20),
+  action VARCHAR(10),
+  note VARCHAR(255)
+);
+```
+
+## Alur Data
+
+- Endpoint `senddata.php` menerima data sensor dalam format JSON dan menyimpannya ke tabel `sensor_realtime`.
+- `get_realtime.php?hours=6` mengambil data beberapa jam terakhir dari `sensor_realtime`.
+- `get_hourly.php?days=7` mengambil data agregat per jam dari `sensor_hourly`.
+- Halaman `index.html` menampilkan grafik dan akan memuat data 1H, 6H, 24H atau 7D dari basis data sesuai pilihan pengguna.
+
+## API Kunci
+
+Untuk mengirim data ke `senddata.php`, sertakan header `X-API-KEY: GROWY_SECRET_123` dan JSON:
+
+```json
+{
+  "suhu": 25.4,
+  "kelembapan_tanah": 60,
+  "ph": 6.5,
+  "relay": 1
+}
+```

--- a/public/index.html
+++ b/public/index.html
@@ -525,6 +525,7 @@
     let historicalData = { timestamps: [], temperature: [], humidity: [], ph: [] };
     let chart = null;
     let maxDataPoints = 60;
+    let currentRange = '1h';
 
     // ==== HIVE MQ CLOUD (WSS TLS) + AUTH ====
     const MQTT_CONFIG = {
@@ -549,6 +550,7 @@
       initializeDashboard();
       initializeMQTT();
       initializeChart();     // chart versi baru
+      updateChartTimeRange('1h');  // load initial chart data
     });
 
     // ================== UI BASICS ==================
@@ -914,7 +916,8 @@
     function getCss(v){ return getComputedStyle(document.documentElement).getPropertyValue(v) || '#666'; }
 
     function addDataPoint(type, value){
-      const t = new Date().toLocaleTimeString();
+      const now = new Date();
+      const t = currentRange==='7d' ? now.toLocaleDateString() : now.toLocaleTimeString();
       const needNew = (historicalData.timestamps.length===0 || historicalData.timestamps.at(-1)!==t);
       if (needNew){
         historicalData.timestamps.push(t);
@@ -943,12 +946,42 @@
       chart.data.datasets[2].data = historicalData.ph;
       chart.update('none');
     }
-    function updateChartTimeRange(range){
+    async function loadChartData(range){
+      let url;
+      if(range==='7d'){
+        url=`get_hourly.php?days=7`;
+      } else if(range==='24h'){
+        url=`get_realtime.php?hours=24`;
+      } else if(range==='6h'){
+        url=`get_realtime.php?hours=6`;
+      } else {
+        url=`get_realtime.php?hours=1`;
+      }
+      try{
+        const res = await fetch(url);
+        const json = await res.json();
+        historicalData = { timestamps: [], temperature: [], humidity: [], ph: [] };
+        json.data.forEach(r=>{
+          const ts = new Date((r.t ?? r.hour_start)*1000);
+          const label = range==='7d' ? ts.toLocaleDateString() : ts.toLocaleTimeString();
+          historicalData.timestamps.push(label);
+          historicalData.temperature.push(r.suhu ?? r.suhu_avg);
+          historicalData.humidity.push(r.kelembapan_tanah ?? r.kelembapan_avg);
+          historicalData.ph.push(r.ph ?? r.ph_avg);
+        });
+        trimPoints();
+        renderChart();
+      } catch(err){
+        console.error('Failed to load chart data', err);
+      }
+    }
+    async function updateChartTimeRange(range){
+      currentRange = range;
       if (range==='1h') maxDataPoints=60;
       else if (range==='6h') maxDataPoints=72;
       else if (range==='24h') maxDataPoints=96;
       else if (range==='7d') maxDataPoints=168;
-      trimPoints(); renderChart();
+      await loadChartData(range);
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Document MySQL setup with table schemas for realtime, hourly, and pump log data
- Fetch sensor_realtime and sensor_hourly records to populate charts automatically

## Testing
- `php -l public/index.html`
- `php -l public/get_realtime.php`
- `php -l public/get_hourly.php`


------
https://chatgpt.com/codex/tasks/task_e_689e887fec9c8325b9a0cb71e396cee5