### PR TITLE
Add MySQL service and document DB usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,26 @@ Proyek ini menampilkan data sensor dan kontrol pompa melalui web. Aplikasi berja
 ## Menjalankan Aplikasi
 
 1. Pastikan **Docker** dan **Docker Compose** terpasang.
-2. Jalankan layanan web:
+2. Jalankan layanan web dan basis data:
    ```bash
    docker-compose up -d
    ```
+   Perintah di atas akan memulai kontainer web serta kontainer MySQL yang otomatis terisi dengan skema dan data contoh dari folder `database/`.
 3. Buka `http://localhost:5500` di peramban.
 
 ## Konfigurasi Basis Data
 
-Aplikasi memerlukan basis data MySQL/MariaDB. Kredensial dapat diatur melalui variabel lingkungan `DB_HOST`, `DB_USER`, `DB_PASS`, dan `DB_NAME` (nilai bawaan: `localhost`, `manunggal`, `jaya333`, `manunggaljaya`).
+Secara bawaan, `docker-compose` akan menjalankan MySQL dengan kredensial berikut:
+
+- host: `db`
+- database: `manunggaljaya`
+- user: `manunggal`
+- password: `jaya333`
+
+Anda dapat mengubah kredensial tersebut melalui variabel lingkungan `DB_HOST`, `DB_USER`, `DB_PASS`, dan `DB_NAME`.
 
 ### Struktur Tabel
-Jalankan perintah berikut di basis data yang digunakan:
+Jika menjalankan basis data secara manual, buat tabel berikut:
 
 ```sql
 CREATE TABLE sensor_realtime (
@@ -62,15 +70,7 @@ Folder `database/` menyediakan skrip SQL untuk mengisi basis data dengan data du
 - `seed_24h.sql` — contoh data 24 jam (juga memenuhi grafik 6 jam).
 - `seed_7d.sql` — contoh data agregat 7 hari.
 
-Contoh cara menjalankan skrip pada basis data `manunggaljaya`:
-
-```bash
-mysql -u root -p manunggaljaya < database/schema.sql
-mysql -u root -p manunggaljaya < database/seed_24h.sql
-mysql -u root -p manunggaljaya < database/seed_7d.sql
-```
-
-Setelah skrip dijalankan, grafik pada halaman web akan menampilkan data contoh untuk rentang waktu 6 jam, 24 jam, dan 7 hari.
+Pada penggunaan `docker-compose`, berkas-berkas SQL di folder `database/` akan dijalankan secara otomatis saat kontainer MySQL pertama kali dibuat, sehingga contoh data untuk grafik telah tersedia.
 
 ## API Kunci
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,14 +1,38 @@
 version: "3.8"
 services:
+  db:
+    image: mysql:8.0
+    container_name: manunggal-db
+    restart: unless-stopped
+    environment:
+      - MYSQL_DATABASE=manunggaljaya
+      - MYSQL_USER=manunggal
+      - MYSQL_PASSWORD=jaya333
+      - MYSQL_ROOT_PASSWORD=root
+      - TZ=Asia/Makassar
+    volumes:
+      - ./database:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   web:
     build: .
     container_name: manunggal
+    depends_on:
+      - db
     ports:
       - "5500:80"
     volumes:
       - ./public:/var/www/html:ro   # sudah pas
     environment:
       - TZ=Asia/Makassar            # jam container
+      - DB_HOST=db
+      - DB_USER=manunggal
+      - DB_PASS=jaya333
+      - DB_NAME=manunggaljaya
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/"]
       interval: 30s


### PR DESCRIPTION
## Summary
- add dedicated MySQL container and wire web service to it
- document bundled database and default credentials

## Testing
- `php -l public/get_hourly.php public/get_pump_logs.php public/get_realtime.php public/log_pump.php public/senddata.php`
- `python - <<'PY'
import yaml
with open('docker-compose.yaml') as f:
    data = yaml.safe_load(f)
print('Services:', list(data.get('services', {}).keys()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689e969e4e188325b492ebb30beb84f1