### PR TITLE
Persist moisture control settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ CREATE TABLE pump_logs (
   action VARCHAR(10),
   note VARCHAR(255)
 );
+
+CREATE TABLE moisture_config (
+  id TINYINT PRIMARY KEY,
+  enabled TINYINT NOT NULL,
+  threshold INT NOT NULL,
+  target INT NOT NULL
+);
+
+INSERT INTO moisture_config (id, enabled, threshold, target)
+VALUES (1, 0, 30, 70);
 ```
 
 ## Alur Data
@@ -60,6 +70,7 @@ CREATE TABLE pump_logs (
 - `get_realtime.php?hours=6` mengambil data beberapa jam terakhir dari `sensor_realtime`.
 - `get_hourly.php?days=7` mengambil data agregat per jam dari `sensor_hourly`.
 - Halaman `index.html` menampilkan grafik dan akan memuat data 1H, 6H, 24H atau 7D dari basis data sesuai pilihan pengguna.
+- `moisture_config.php` menyediakan penyimpanan konfigurasi otomasi kelembapan sehingga nilai ambang tetap tersimpan meski halaman direfresh.
 
 ### Contoh Basis Data untuk Grafik
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -23,3 +23,13 @@ CREATE TABLE pump_logs (
   action VARCHAR(10),
   note VARCHAR(255)
 );
+
+CREATE TABLE moisture_config (
+  id TINYINT PRIMARY KEY,
+  enabled TINYINT NOT NULL,
+  threshold INT NOT NULL,
+  target INT NOT NULL
+);
+
+INSERT INTO moisture_config (id, enabled, threshold, target)
+VALUES (1, 0, 30, 70);

--- a/public/index.html
+++ b/public/index.html
@@ -591,6 +591,7 @@
       resetSensorDisplays();
       togglePump(sensorData.pumpStatus, false);
       updateLastUpdateTime();
+      loadMoistureConfig();
       updateScheduleStatuses();
       loadPumpLogs();
     }
@@ -852,6 +853,11 @@
       const threshold = parseInt(document.getElementById('moistureThreshold')?.value);
       const target = parseInt(document.getElementById('moistureTarget')?.value);
       if ([threshold,target].some(x=>Number.isNaN(x)) || threshold >= target) { alert('Please enter valid threshold values (threshold < target)'); return; }
+      fetch('moisture_config.php', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({enabled, threshold, target})
+      }).catch(()=>{});
       scheduleData.moistureControl = { enabled, threshold, target };
       updateMoistureStatus();
       addLog(`Moisture control ${enabled?'enabled':'disabled'} (${threshold}-${target}%)`);
@@ -876,6 +882,21 @@
       } else if(sensorData.pumpStatus && sensorData.humidity > target){
         togglePump(false, true, 'moisture');
       }
+    }
+
+    function loadMoistureConfig(){
+      fetch('moisture_config.php')
+        .then(r=>r.json())
+        .then(res=>{
+          if(res.ok){
+            const {enabled, threshold, target} = res.data;
+            scheduleData.moistureControl = { enabled: !!enabled, threshold, target };
+            const chk=document.getElementById('moistureAutoEnable'); if(chk) chk.checked=!!enabled;
+            const th=document.getElementById('moistureThreshold'); if(th) th.value=threshold;
+            const ta=document.getElementById('moistureTarget'); if(ta) ta.value=target;
+            updateMoistureStatus();
+          }
+        }).catch(()=>{});
     }
 
     // ===== Time Left =====

--- a/public/moisture_config.php
+++ b/public/moisture_config.php
@@ -1,0 +1,57 @@
+<?php
+$DB_HOST = getenv('DB_HOST') ?: 'localhost';
+$DB_USER = getenv('DB_USER') ?: 'manunggal';
+$DB_PASS = getenv('DB_PASS') ?: 'jaya333';
+$DB_NAME = getenv('DB_NAME') ?: 'manunggaljaya';
+header('Content-Type: application/json');
+
+$mysqli = @new mysqli($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
+if ($mysqli->connect_errno) {
+  http_response_code(500);
+  echo json_encode(["ok"=>false,"error"=>"DB connect: ".$mysqli->connect_error]);
+  exit;
+}
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method === 'GET') {
+  $res = $mysqli->query('SELECT enabled, threshold, target FROM moisture_config WHERE id=1');
+  $row = $res ? $res->fetch_assoc() : null;
+  if (!$row) { $row = ['enabled'=>0,'threshold'=>30,'target'=>70]; }
+  $row['enabled'] = (int)$row['enabled'];
+  echo json_encode(['ok'=>true,'data'=>$row]);
+  exit;
+} elseif ($method === 'POST') {
+  $data = json_decode(file_get_contents('php://input'), true);
+  if (!is_array($data) || !isset($data['enabled'],$data['threshold'],$data['target'])) {
+    http_response_code(400);
+    echo json_encode(['ok'=>false,'error'=>'Invalid data']);
+    exit;
+  }
+  $enabled = $data['enabled'] ? 1 : 0;
+  $threshold = (int)$data['threshold'];
+  $target = (int)$data['target'];
+  if ($threshold >= $target) {
+    http_response_code(400);
+    echo json_encode(['ok'=>false,'error'=>'threshold must be < target']);
+    exit;
+  }
+  $stmt = $mysqli->prepare('INSERT INTO moisture_config (id, enabled, threshold, target) VALUES (1,?,?,?) ON DUPLICATE KEY UPDATE enabled=VALUES(enabled), threshold=VALUES(threshold), target=VALUES(target)');
+  if (!$stmt) {
+    http_response_code(500);
+    echo json_encode(['ok'=>false,'error'=>'Prepare failed']);
+    exit;
+  }
+  $stmt->bind_param('iii', $enabled, $threshold, $target);
+  if (!$stmt->execute()) {
+    http_response_code(500);
+    echo json_encode(['ok'=>false,'error'=>'Execute failed: '.$stmt->error]);
+    exit;
+  }
+  echo json_encode(['ok'=>true]);
+  exit;
+} else {
+  http_response_code(405);
+  echo json_encode(['ok'=>false,'error'=>'Method not allowed']);
+  exit;
+}
+?>


### PR DESCRIPTION
## Summary
- add `moisture_config` table to store automation thresholds
- provide `moisture_config.php` API for retrieving and updating settings
- load and save moisture control values from the dashboard and document setup

## Testing
- `php -l public/moisture_config.php`
- `php -l public/senddata.php`
- `php -l public/get_realtime.php`
- `php -l public/get_hourly.php`
- `php -l public/log_pump.php`
- `php -l public/get_pump_logs.php`
- `curl http://127.0.0.1:8000/moisture_config.php` *(fails: No such file or directory)*
- `curl -X POST http://127.0.0.1:8000/moisture_config.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e9fcf74c08325a4bf2b69c3e44600