### PR TITLE
Ensure moisture control settings persist in database

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -852,15 +852,27 @@
       const enabled = document.getElementById('moistureAutoEnable')?.checked;
       const threshold = parseInt(document.getElementById('moistureThreshold')?.value);
       const target = parseInt(document.getElementById('moistureTarget')?.value);
-      if ([threshold,target].some(x=>Number.isNaN(x)) || threshold >= target) { alert('Please enter valid threshold values (threshold < target)'); return; }
+      if ([threshold,target].some(x=>Number.isNaN(x)) || threshold >= target) {
+        alert('Please enter valid threshold values (threshold < target)');
+        return;
+      }
       fetch('moisture_config.php', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
         body: JSON.stringify({enabled, threshold, target})
-      }).catch(()=>{});
-      scheduleData.moistureControl = { enabled, threshold, target };
-      updateMoistureStatus();
-      addLog(`Moisture control ${enabled?'enabled':'disabled'} (${threshold}-${target}%)`);
+      })
+        .then(r=>r.json())
+        .then(res=>{
+          if(res.ok){
+            const {enabled:e, threshold:t, target:ta} = res.data;
+            scheduleData.moistureControl = { enabled: !!e, threshold: t, target: ta };
+            updateMoistureStatus();
+            addLog(`Moisture control ${enabled?'enabled':'disabled'} (${threshold}-${target}%)`);
+          } else {
+            alert('Failed to save moisture config');
+          }
+        })
+        .catch(()=>{ alert('Failed to save moisture config'); });
     }
 
     function updateMoistureStatus(){

--- a/public/moisture_config.php
+++ b/public/moisture_config.php
@@ -47,11 +47,11 @@ if ($method === 'GET') {
     echo json_encode(['ok'=>false,'error'=>'Execute failed: '.$stmt->error]);
     exit;
   }
-  echo json_encode(['ok'=>true]);
+  echo json_encode(['ok'=>true,'data'=>['enabled'=>$enabled,'threshold'=>$threshold,'target'=>$target]]);
   exit;
 } else {
   http_response_code(405);
   echo json_encode(['ok'=>false,'error'=>'Method not allowed']);
   exit;
 }
-?>
+


### PR DESCRIPTION
## Summary
- Save moisture automation settings only after confirming the backend database update.
- API now returns saved moisture configuration data for better synchronization.

## Testing
- `php -l public/moisture_config.php`


------
https://chatgpt.com/codex/tasks/task_e_689eaa77712083259d350a10cce2e7c0